### PR TITLE
ignore SSL errors from activation.sls.microsoft.com

### DIFF
--- a/src/web-service/aspnet/ActivationWs/Activation.cs
+++ b/src/web-service/aspnet/ActivationWs/Activation.cs
@@ -99,6 +99,9 @@ namespace ActivationWs
         }
 
         private static HttpWebRequest CreateWebRequest(XDocument soapRequest) {
+            // Accept all SSL certificates to handle broken certificates from the activation service
+            ServicePointManager.ServerCertificateValidationCallback =
+                (sender, certificate, chain, sslPolicyErrors) => true;
             HttpWebRequest webRequest = (HttpWebRequest)WebRequest.Create(Uri);
             webRequest.Accept = "text/xml";
             webRequest.ContentType = "text/xml; charset=\"utf-8\"";


### PR DESCRIPTION
Since somehow the certificate configuration of activation.sls.microsoft.com seems to be broken, i changed the HttpWebRequest to ignore SSL errors.

When using the Activation, the webservice returned:
```
System.Net.WebException: The underlying connection was closed: Could not establish trust relationship for the SSL/TLS secure channel. ---> System.Security.Authentication.AuthenticationException: The remote certificate is invalid according to the validation procedure. at System.Net.Security.SslState.StartSendAuthResetSignal(ProtocolToken message, AsyncProtocolRequest asyncRequest, Exception exception) at System.Net.Security.SslState.CheckCompletionBeforeNextReceive(ProtocolToken message, AsyncProtocolRequest asyncRequest) at System.Net.Security.SslState.ProcessReceivedBlob(Byte[] buffer, Int32 count, AsyncProtocolRequest asyncRequest) at System.Net.Security.SslState.StartReceiveBlob(Byte[] buffer, AsyncProtocolRequest asyncRequest) at System.Net.Security.SslState.CheckCompletionBeforeNextReceive(ProtocolToken message, AsyncProtocolRequest asyncRequest) at System.Net.Security.SslState.ProcessReceivedBlob(Byte[] buffer, Int32 count, AsyncProtocolRequest asyncRequest) at System.Net.Security.SslState.StartReceiveBlob(Byte[] buffer, AsyncProtocolRequest asyncRequest) at System.Net.Security.SslState.CheckCompletionBeforeNextReceive(ProtocolToken message, AsyncProtocolRequest asyncRequest) at System.Net.Security.SslState.ProcessReceivedBlob(Byte[] buffer, Int32 count, AsyncProtocolRequest asyncRequest) at System.Net.Security.SslState.StartReceiveBlob(Byte[] buffer, AsyncProtocolRequest asyncRequest) at System.Net.Security.SslState.CheckCompletionBeforeNextReceive(ProtocolToken message, AsyncProtocolRequest asyncRequest) at System.Net.Security.SslState.ProcessReceivedBlob(Byte[] buffer, Int32 count, AsyncProtocolRequest asyncRequest) at System.Net.Security.SslState.StartReceiveBlob(Byte[] buffer, AsyncProtocolRequest asyncRequest) at System.Net.Security.SslState.CheckCompletionBeforeNextReceive(ProtocolToken message, AsyncProtocolRequest asyncRequest) at System.Net.Security.SslState.ProcessReceivedBlob(Byte[] buffer, Int32 count, AsyncProtocolRequest asyncRequest) at System.Net.Security.SslState.StartReceiveBlob(Byte[] buffer, AsyncProtocolRequest asyncRequest) at System.Net.Security.SslState.CheckCompletionBeforeNextReceive(ProtocolToken message, AsyncProtocolRequest asyncRequest) at System.Net.Security.SslState.ProcessReceivedBlob(Byte[] buffer, Int32 count, AsyncProtocolRequest asyncRequest) at System.Net.Security.SslState.StartReceiveBlob(Byte[] buffer, AsyncProtocolRequest asyncRequest) at System.Net.Security.SslState.CheckCompletionBeforeNextReceive(ProtocolToken message, AsyncProtocolRequest asyncRequest) at System.Net.Security.SslState.ForceAuthentication(Boolean receiveFirst, Byte[] buffer, AsyncProtocolRequest asyncRequest, Boolean renegotiation) at System.Net.Security.SslState.ProcessAuthentication(LazyAsyncResult lazyResult) at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx) at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx) at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state) at System.Net.TlsStream.ProcessAuthentication(LazyAsyncResult result) at System.Net.TlsStream.Write(Byte[] buffer, Int32 offset, Int32 size) at System.Net.PooledStream.Write(Byte[] buffer, Int32 offset, Int32 size) at System.Net.ConnectStream.WriteHeaders(Boolean async) --- End of inner exception stack trace --- at System.Net.HttpWebRequest.EndGetResponse(IAsyncResult asyncResult) at ActivationWs.ActivationHelper.CallWebService(Int32 requestType, String installationId, String extendedProductId) in C:\Temp\activationws\src\web-service\aspnet\ActivationWs\Activation.cs:line 54 at ActivationWs.ActivationService.AcquireConfirmationId(String installationId, String extendedProductId) in C:\Temp\activationws\src\web-service\aspnet\ActivationWs\ActivationWs.asmx.cs:line 20
```

so i quickly verified with Edge if the SSL config is really broken:

```
This server couldn't prove that it's activation.sls.microsoft.com; its security certificate does not specify Subject Alternative Names. This may be caused by a misconfiguration or an attacker intercepting your connection.
```

Even though the CN's are set correctly, it seems that without a SAN nowadays it does not verify correctly.

```
CN = activation.sls.microsoft.com 
CN = *.activation.sls.microsoft.com 
CN = validation.sls.microsoft.com 
CN = *.validation.sls.microsoft.com 
CN = activation-v2.sls.microsoft.com 
CN = *.activation-v2.sls.microsoft.com 
CN = validation-v2.sls.microsoft.com 
CN = *.validation-v2.sls.microsoft.com 
CN = activation-v3.sls.microsoft.com 
CN = *.activation-v3.sls.microsoft.com 
CN = validation-v3.sls.microsoft.com 
CN = *.validation-v3.sls.microsoft.com 
CN = sls.microsoft.com 
CN = *.sls.microsoft.com 
```

With this workaround everything works again like expected.